### PR TITLE
Add solution

### DIFF
--- a/src/main/java/ru/hh/kafkahw/Sender.java
+++ b/src/main/java/ru/hh/kafkahw/Sender.java
@@ -16,7 +16,8 @@ public class Sender {
   public void doSomething(String topic, String message) {
     try {
       producer.send(topic, message);
-    } catch (Exception ignore) {
+    } catch (RuntimeException e) {
+      doSomething(topic, message);
     }
   }
 }


### PR DESCRIPTION
Добавлено решение домашнего задания.

В файле Sender исправлена отправка сообщения - раньше отправлялись не все сообщения. Теперь сообщение отправляется повторно, пока producer.send не отработает без исключений, хотя на кафку монут быть отправлены дублирующиеся сообщения.

Чтобы исключить повторную обработку в TopicListener добавлена проверка, что сообщение ранее не обработано. Это важно в листенерах atMostOnce и exactlyOnce.

Также теперь сообщения обрабатываются до тех пор, пока не произойдет успешная обработка. Это важно в листенерах atLeastOnce и exactlyOnce.